### PR TITLE
FHIR::Model.search method URI Encodes twice

### DIFF
--- a/fhir_client.gemspec
+++ b/fhir_client.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'minitest'
   s.add_development_dependency 'test-unit'
+  s.add_development_dependency 'webmock'
 end

--- a/lib/client_interface.rb
+++ b/lib/client_interface.rb
@@ -295,7 +295,7 @@ module FHIR
     end
 
     def get(path, headers)
-      url = URI(URI.escape(build_url(path))).to_s
+      url = Addressable::URI.parse(build_url(path)).to_s
       FHIR.logger.info "GETTING: #{url}"
       headers = clean_headers(headers)
       if @use_oauth2_auth

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,7 @@ require_relative '../lib/fhir_client'
 
 require 'pry'
 require 'minitest/autorun'
+require 'webmock/test_unit'
 require 'bundler/setup'
 require 'test/unit'
 require 'turn'

--- a/test/unit/basic_test.rb
+++ b/test/unit/basic_test.rb
@@ -1,4 +1,5 @@
 require_relative '../test_helper'
+WebMock.allow_net_connect!
 
 class BasicTest < Test::Unit::TestCase
 

--- a/test/unit/client_interface_sections/search_test.rb
+++ b/test/unit/client_interface_sections/search_test.rb
@@ -1,0 +1,24 @@
+require_relative '../../test_helper'
+
+class ClientInterfaceSearchTest < Test::Unit::TestCase
+  def client
+    @client ||= FHIR::Client.new("feed-test")
+  end
+
+  def test_url_encoding_only_happens_once
+    stub_request(:get, /feed-test/)
+    reply = client.search(
+      FHIR::Appointment,
+      {
+        search: {
+          parameters: {
+            'patient' => 'test',
+            'date' => '>2016-01-01'
+          }
+        }
+      }
+    )
+    assert_equal 'feed-test/Appointment?date=%3E2016-01-01&patient=test',
+                 reply.request[:url]
+  end
+end


### PR DESCRIPTION
* Addresses including search parameters such as `>2016-01-01` get
  encoded twice, resulting in `%253E2016-01-01` instead of
  `%3E2016-01-01`
* Utilize the already-included Addressable gem to ensure that the URL is
  safe. This method was already use by the 'search' method, via
  'resource_url'. Running it through twice seems to be safe.
* Add a test to ensure that our search parameters get passed safely
  through search.
* Tests add WebMock, which allows us to run tests against fake data
  easily. This lets us verify the URL we attempted to use with little
  effort.